### PR TITLE
Cleaned references to contextID when it's useless

### DIFF
--- a/bepo/bepoxkb/background.js
+++ b/bepo/bepoxkb/background.js
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var contextID = -1;
-
-chrome.input.ime.onFocus.addListener(function(context) {
-  contextID = context.contextID;
-});
-
-chrome.input.ime.onBlur.addListener(function(context) {
-  contextID = -1;
-});
-
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       return false;

--- a/dvorakleft/dvorakleftxkb/background.js
+++ b/dvorakleft/dvorakleftxkb/background.js
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var contextID = -1;
-
-chrome.input.ime.onFocus.addListener(function(context) {
-  contextID = context.contextID;
-});
-
-chrome.input.ime.onBlur.addListener(function(context) {
-  contextID = -1;
-});
-
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       return false;

--- a/dvorakright/dvorakrightxkb/background.js
+++ b/dvorakright/dvorakrightxkb/background.js
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var contextID = -1;
-
-chrome.input.ime.onFocus.addListener(function(context) {
-  contextID = context.contextID;
-});
-
-chrome.input.ime.onBlur.addListener(function(context) {
-  contextID = -1;
-});
-
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       return false;

--- a/dvp-dvorak/background.js
+++ b/dvp-dvorak/background.js
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var contextID = -1;
-
-chrome.input.ime.onFocus.addListener(function(context) {
-  contextID = context.contextID;
-});
-
-chrome.input.ime.onBlur.addListener(function(context) {
-  contextID = -1;
-});
-
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       return false;

--- a/pldvorak/background.js
+++ b/pldvorak/background.js
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var contextID = -1;
-
-chrome.input.ime.onFocus.addListener(function(context) {
-  contextID = context.contextID;
-});
-
-chrome.input.ime.onBlur.addListener(function(context) {
-  contextID = -1;
-});
-
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       return false;

--- a/svorak/background.js
+++ b/svorak/background.js
@@ -12,16 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var contextID = -1;
-
-chrome.input.ime.onFocus.addListener(function(context) {
-  contextID = context.contextID;
-});
-
-chrome.input.ime.onBlur.addListener(function(context) {
-  contextID = -1;
-});
-
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       return false;


### PR DESCRIPTION
Until http://crbug.com/337082 is fixed, let's clean the `background.js` files where declarations of `contextID` are not needed.
