### PR TITLE
Add compose sequences for arrows

### DIFF
--- a/composekey/background.js
+++ b/composekey/background.js
@@ -400,6 +400,8 @@ var lut = {
 "=E": "\u20ac", // EuroSign # EURO SIGN
 "^SM": "\u2120", // SERVICE MARK
 "^TM": "\u2122", // TRADE MARK SIGN
+"<-": "\u2190", // LEFTWARDS ARROW
+"->": "\u2192", // RIGHTWARDS ARROW
 "\\\\": "\u301d", // REVERSED DOUBLE PRIME QUOTATION MARK
 "//": "\u301e", // DOUBLE PRIME QUOTATION MARK
 };


### PR DESCRIPTION
These are in [standard X11 bindings](http://www.x.org/releases/X11R7.7/doc/libX11/i18n/compose/en_US.UTF-8.html) for `en_US`.

IMHO the whole X11 compose table could be added, but I'll leave that to another PR.