### PR TITLE
Do not require Compose key release

### DIFF
--- a/composekey/README
+++ b/composekey/README
@@ -2,9 +2,10 @@ This adds a compose key (right alt key) to a US qwerty keyboard layout (see chro
 
 How to use:
  - press right alt key
- - release
+ - release (possibly after you started typing a combination)
  - type a combination
  - if there is a match the conversion will happen automatically otherwise you get what you typed
+ - you can abort the compose mode by pressing the compose key again
 
 ** Full list of supported sequences **
 Format: output sequence(s) comment

--- a/composekey/manifest.json
+++ b/composekey/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ComposeKey",
-  "version": "1.2",
+  "version": "1.3",
   "manifest_version": 2,
   "description": "Compose Key for Chrome OS",
   "background": {


### PR DESCRIPTION
Keys pressed immediately after Compose key keydown event and before its
keyup event won't break out from the Compose state anymore. That allows
for key rollover and faster typing.

Also, allow to explicitly break out of Compose mode by pressing Compose
key again.

Bumps ComposeKey extension version to 1.3.

Fixes: issue #12.