### PR TITLE
add option to set which key is Compose

### DIFF
--- a/composekey/background.js
+++ b/composekey/background.js
@@ -686,13 +686,26 @@ function unravelComposition() {
   resetComposition();
 }
 
+var composeKey = localStorage.getItem('key')
+
+function setKey(key) {
+  composeKey = key;
+  localStorage.setItem('key', key);
+  console.log('set key to ' + key);
+}
+
+if (!composeKey) {
+  chrome.storage.sync.get({ key: 'AltRight' }, function(saved) {
+    if (!composeKey) {
+      setKey(saved.key);
+    }
+  });
+}
 
 chrome.input.ime.onKeyEvent.addListener(
     function(engineID, keyData) {
       var handled = false;
-      
-      var isComposeKeyDownEvent = (keyData.code == "AltRight" && keyData.type == "keydown");
-      if (isComposeKeyDownEvent) {
+      if (keyData.code == composeKey && keyData.type == "keydown") {
         switch (state) {
           case States.WAITING_FOR_COMPOSE_KEY:
             state = States.COMPOSING;
@@ -715,6 +728,8 @@ chrome.input.ime.onKeyEvent.addListener(
          if (compositionDone()) {
             unravelComposition();
          }
+        } else if (keyData.code == composeKey && keyData.type == "keyup") {
+          handled = true;
         }
       }
       

--- a/composekey/manifest.json
+++ b/composekey/manifest.json
@@ -1,13 +1,14 @@
 {
   "name": "ComposeKey",
-  "version": "1.4",
+  "version": "1.5",
   "manifest_version": 2,
   "description": "Compose Key for Chrome OS",
   "background": {
     "scripts": ["background.js"]
   },
   "permissions": [
-    "input"
+    "input",
+    "storage"
   ],
   "input_components": [
     {
@@ -18,5 +19,9 @@
       "language": "en-US",
       "layouts": ["us"]
     }
-  ]
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  }
 }

--- a/composekey/options.html
+++ b/composekey/options.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head><title>ComposeKey Options</title></head>
+  <body>
+    <p>
+      <label for="key">
+        Key:
+        <select id="key">
+          <option value="AltRight">Right Alt</option>
+          <option value="AltLeft">Left Alt</option>
+          <option value="ContextMenu">Menu</option>
+          <option value="CapsLock">Caps Lock</option>
+          <option value="ShiftRight">Right Shift</option>
+          <option value="ShiftLeft">Left Shift</option>
+          <option value="ControlRight">Right Control</option>
+          <option value="ControlLeft">Left Control</option>
+        </select>
+      </label>
+    </p>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/composekey/options.js
+++ b/composekey/options.js
@@ -1,0 +1,22 @@
+function saveAndSync() {
+  var key = document.getElementById('key').value;
+  chrome.extension.getBackgroundPage().setKey(key);
+
+  chrome.storage.sync.set({ key: key }, function() {
+    console.log("sync'd key as " + key);
+  })
+}
+
+function restore() {
+  document.getElementById('key').value =
+      chrome.extension.getBackgroundPage().composeKey;
+  document.addEventListener('storage', function(event) {
+    var old = document.getElementById('key').value;
+    if (event.key == 'key' && event.newValue != old) {
+      document.getElementById('key').value = event.newValue;
+    }
+  })
+}
+
+document.addEventListener('DOMContentLoaded', restore);
+document.getElementById('key').addEventListener('input', saveAndSync);


### PR DESCRIPTION
I use "compose:menu" on my Linux systems and would like the same
behavior on ChromeOS.

While I'm adding the option anyway, I went ahead and allowed all
modifier keys except for "OS", which ChromeOS currently does not
appear to forward to the IME handler.

In order to make the Menu key function as Compose (rather than opening
a context menu), I also needed to filter out stray "keyup" events:
otherwise, the "keyup" event for the Menu key opens the menu and loses
text focus.