### PR TITLE
Add international layouts for the English language.

### DIFF
--- a/composekey/README.md
+++ b/composekey/README.md
@@ -3,13 +3,19 @@
 This extension turns the right Alt key into a compose key on a US qwerty
 keyboard layout (see chrome://settings/languages; Compose Key in English (US))
 
-The key sequences used are the same as [Xlib](https://www.x.org/releases/X11R7.7/doc/libX11/i18n/compose/en_US.UTF-8.html)
+The key sequences used are the same as [Xlib](https://www.x.org/releases/current/doc/libX11/i18n/compose/en_US.UTF-8.html)
 for the en_US.UTF-8 locale (though this extension currently does not support the
 full set defined by Xlib).
 
 ## Configuration
 
-By default the right Alt key is configured as the Compose key. The key may be
+To enable the Compose key, open `chrome://settings/inputMethods`
+and select one of the `Compose Key` input methods.
+
+Then, open `chrome://settings/languages` and enable the selected method.
+(You may need to sign out and back in first.)
+
+By default, the right Alt key acts as the Compose key. The key may be
 changed in the extension configuration page.
 
 ## How to use
@@ -18,7 +24,7 @@ changed in the extension configuration page.
 2. Type the desired key sequence as defined below. The proper character will be
    displayed when a key sequence is matched.
 3. You can abort compose mode any time after entering the mode by pressing the
-   Compose key again.
+   Escape key.
 
 ## Full list of supported sequences
 

--- a/composekey/fakes.js
+++ b/composekey/fakes.js
@@ -191,7 +191,7 @@ if (!chrome.input.ime) {
 
       let element = document.activeElement;
 
-      if (element.selectionStart !== undefined) {
+      if (element.selectionStart != null) {
         let scrollTop = element.scrollTop;
         let prefix = element.value.substring(0, element.selectionStart);
         let suffix = element.value.substring(element.selectionEnd, element.value.length);
@@ -241,5 +241,7 @@ if (!chrome.input.ime) {
         document.activeElement.dispatchEvent(event);
       }
     },
+
+    keyEventHandled: () => {},
   };
 }

--- a/composekey/fakes.js
+++ b/composekey/fakes.js
@@ -1,0 +1,245 @@
+/*
+Copyright 2018 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @fileoverview This file provides fake non-extension implementations of Chrome
+ * extension APIs to facilitate local (non-ChromeOS / non-extension) testing.
+ */
+
+if (chrome == undefined) {
+  var chrome = {};
+}
+
+if (!chrome.runtime) {
+  chrome.runtime = {};
+}
+
+/**
+ * @param {function()} callback
+ * @param {*} message
+ */
+function callWithRuntimeError(callback, message) {
+  if (message !== undefined && message !== null) {
+    chrome.runtime.lastError = {
+      message: '' + message,
+    };
+  }
+
+  try {
+    callback();
+  } finally {
+    delete chrome.runtime.lastError;
+  }
+}
+
+/**
+ * @param {*} parameters Ignored.
+ * @param {function()} callback
+ */
+function reportUnimplemented(parameters, callback) {
+  if (!callback) return;
+
+  callWithRuntimeError(callback, 'chrome.storage is not available');
+};
+
+
+if (!chrome.storage) {
+  let unimplementedStorageArea = Object.freeze({
+    get: reportUnimplemented,
+    getBytesInUse: reportUnimplemented,
+    set: reportUnimplemented,
+    remove: reportUnimplemented,
+    clear: (callback) => { reportUnimplemented(null, callback); },
+  });
+
+  let localStorageArea = Object.freeze({
+    get: (keys, callback) => {
+      let items = {};
+      try {
+        if (keys instanceof String) {
+          items[keys] = localStorage.getItem(keys);
+        } else if (keys instanceof Array) {
+          for (let key of keys) {
+            items[key] = localStorage.getItem(key);
+          }
+        } else {
+          for (let [key, defaultItem] in Object.entries(keys)) {
+            let item = localStorage.getItem(key);
+            if (item === null) item = defaultItem;
+            items[key] = item;
+          }
+        }
+      } catch(error) {
+        if (callback) {
+          callWithRuntimeError(() => { callback(items); }, {
+            message: '' + error,
+          });
+        }
+        return;
+      }
+
+      if (callback) callback(items);
+    },
+
+    getBytesInUse: reportUnimplemented,
+
+    set: (items, callback) => {
+      try {
+        for (let [key, item] in items) {
+          localStorage.setItem(key, item);
+        }
+      } catch(error) {
+        if (callback)
+          callWithRuntimeError(callback, { message: '' + error });
+        return;
+      }
+
+      if (callback) callback();
+    },
+
+    remove: (keys, callback) => {
+      try {
+        if (keys instanceof String) {
+          localStorage.removeItem(keys);
+        } else {
+          for (let key of keys) {
+            localStorage.removeItem(key);
+          }
+        }
+      } catch(error) {
+        if (callback)
+          callWithRuntimeError(callback, { message: '' + error });
+        return;
+      }
+
+      if (callback) callback();
+    },
+
+    clear: (callback) => {
+      try {
+        localStorage.clear();
+      } catch(error) {
+        if (callback)
+          callWithRuntimeError(callback, { message: '' + error });
+        return;
+      }
+
+      if (callback) callback();
+    },
+  });
+
+  chrome.storage = Object.freeze({
+    sync: unimplementedStorageArea,
+    local: localStorageArea,
+    managed: unimplementedStorageArea
+  });
+}
+
+if (!chrome.input) chrome.input = {};
+
+if (!chrome.input.ime) {
+  const engineID = -1;
+
+  chrome.input.ime = {
+    onFocus: { addListener: (callback) => {} },
+
+    onKeyEvent: {
+      addListener: (callback) => {
+        for (const eventName of ['keydown', 'keyup']) {
+          window.addEventListener(eventName, (event) => {
+            event.type = eventName;
+            if (callback(engineID, event)) {
+              console.debug('onKeyEvent: suppressed ', event);
+              event.preventDefault();
+              event.stopPropagation();
+            }
+          });
+        }
+      },
+    },
+
+    commitText: (parameters, callback) => {
+      const text = parameters.text;
+      console.debug('commitText: ', text);
+
+      var textEvent = document.createEvent('TextEvent');
+      textEvent.initTextEvent('textInput',
+                              /*bubbles=*/true,
+                              /*cancelable=*/true,
+                              /*view=*/window,
+                              /*data=*/text,
+                              /*inputMethod=*/0,
+                              /*locale=*/"en-US");
+      document.activeElement.dispatchEvent(textEvent);
+      if (textEvent.defaultPrevented) {
+        console.debug('commitText: Event handler consumed text.');
+        return;
+      }
+
+      let element = document.activeElement;
+
+      if (element.selectionStart !== undefined) {
+        let scrollTop = element.scrollTop;
+        let prefix = element.value.substring(0, element.selectionStart);
+        let suffix = element.value.substring(element.selectionEnd, element.value.length);
+        element.value = prefix + text + suffix;
+        element.selectionStart = prefix.length + text.length;
+        element.selectionEnd = element.selectionStart;
+        element.focus();
+        element.scrollTop = scrollTop;
+        return;
+      }
+
+      if (element.contentEditable == "true") {
+        let scrollTop = element.scrollTop;
+
+        let selection = document.getSelection();
+        if (selection.anchorNode.nodeType != Node.TEXT_NODE) {
+          console.error('commitText: Selection is not a text node.');
+          return;
+        }
+        if (selection.anchorNode !== selection.focusNode) {
+          console.error('commitText: Selection spans multiple nodes.');
+          return;
+        }
+        let content = selection.anchorNode.textContent;
+        let prefix = content.substring(0, selection.anchorOffset);
+        let suffix = content.substring(selection.focusOffset,
+                                       content.length);
+        selection.anchorNode.textContent = prefix + text + suffix;
+
+        // When we update textContent, the selection resets to the beginning of
+        // the node. Move the cursor to the end of the inserted text.
+        element.scrollTop = scrollTop;
+        selection = document.getSelection();
+        for (let n = lengthInCodepoints(prefix) + lengthInCodepoints(text);
+             n > 0;
+             n -= 1) {
+          selection.modify('move', 'forward', 'character');
+        }
+      }
+
+      console.debug('commitText: No editable selection to commit to.');
+    },
+
+    sendKeyEvents: (parameters, callback) => {
+      console.debug('sendKeyEvents: ', parameters.keyData);
+      for (let event of parameters.keyData) {
+        document.activeElement.dispatchEvent(event);
+      }
+    },
+  };
+}

--- a/composekey/manifest.json
+++ b/composekey/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ComposeKey",
-  "version": "1.5",
+  "version": "1.6",
   "manifest_version": 2,
   "description": "Compose Key for Chrome OS",
   "background": {
@@ -12,12 +12,100 @@
   ],
   "input_components": [
     {
-      "name": "Compose Key",
+      "name": "Compose Key (US)",
       "type": "ime",
       "id": "compose_key",
-      "description": "Adds Compose key functionality to Chrome OS",
+      "description": "Adds Compose key functionality to the US keyboard.",
       "language": "en-US",
       "layouts": ["us"]
+    },
+    {
+      "name": "Compose Key (US International)",
+      "type": "ime",
+      "id": "compose_key_us_intl",
+      "description": "Adds Compose key functionality to the US International keyboard.",
+      "language": "en-US",
+      "layouts": ["us(intl)"]
+    },
+    {
+      "name": "Compose Key (US International (PC))",
+      "type": "ime",
+      "id": "compose_key_us_alt_intl",
+      "description": "Adds Compose key functionality to the US International (PC) keyboard.",
+      "language": "en-US",
+      "layouts": ["us(intl_pc)"]
+    },
+    {
+      "name": "Compose Key (US Extended)",
+      "type": "ime",
+      "id": "compose_key_us_extended",
+      "description": "Adds Compose key functionality to the US Extended keyboard.",
+      "language": "en-US",
+      "layouts": ["us(altgr-intl)"]
+    },
+    {
+      "name": "Compose Key (US Dvorak)",
+      "type": "ime",
+      "id": "compose_key_us_dvorak",
+      "description": "Adds Compose key functionality to the US Dvorak keyboard.",
+      "language": "en-US",
+      "layouts": ["us(dvorak)"]
+    },
+    {
+      "name": "Compose Key (US Programmer Dvorak)",
+      "type": "ime",
+      "id": "compose_key_us_dvp",
+      "description": "Adds Compose key functionality to the US Programmer Dvorak keyboard.",
+      "language": "en-US",
+      "layouts": ["us(dvp)"]
+    },
+    {
+      "name": "Compose Key (US Colemak)",
+      "type": "ime",
+      "id": "compose_key_us_colemak",
+      "description": "Adds Compose key functionality to the US Colemak keyboard.",
+      "language": "en-US",
+      "layouts": ["us(colemak)"]
+    },
+    {
+      "name": "Compose Key (US Workman)",
+      "type": "ime",
+      "id": "compose_key_us_workman",
+      "description": "Adds Compose key functionality to the US Workman keyboard.",
+      "language": "en-US",
+      "layouts": ["us(workman)"]
+    },
+    {
+      "name": "Compose Key (US Workman International)",
+      "type": "ime",
+      "id": "compose_key_us_workman_intl",
+      "description": "Adds Compose key functionality to the US Workman International keyboard.",
+      "language": "en-US",
+      "layouts": ["us(workman-intl)"]
+    },
+    {
+      "name": "Compose Key (Canadian English)",
+      "type": "ime",
+      "id": "compose_key_ca_eng",
+      "description": "Adds Compose key functionality to the US Workman keyboard.",
+      "language": "en-CA",
+      "layouts": ["ca(eng)"]
+    },
+    {
+      "name": "Compose Key (UK)",
+      "type": "ime",
+      "id": "compose_key_gb_extd",
+      "description": "Adds Compose key functionality to the UK keyboard.",
+      "language": "en-GB",
+      "layouts": ["gb(extd)"]
+    },
+    {
+      "name": "Compose Key (UK Dvorak)",
+      "type": "ime",
+      "id": "compose_key_gb_dvorak",
+      "description": "Adds Compose key functionality to the US Workman keyboard.",
+      "language": "en-GB",
+      "layouts": ["gb(dvorak)"]
     }
   ],
   "options_ui": {

--- a/composekey/options.html
+++ b/composekey/options.html
@@ -1,22 +1,63 @@
 <!DOCTYPE html>
 <html>
-  <head><title>ComposeKey Options</title></head>
+  <head>
+    <title>ComposeKey Options</title>
+    <style>
+      * { font-family: sans-serif; }
+      p { max-width: 70ex; }
+      code {
+        font-family: monospace;
+        white-space: nowrap;
+        user-select: all;
+      }
+      body > section {
+        border: thin solid black;
+        padding: 1ex;
+      }
+      textarea, [contenteditable='true'] {
+        font-family: monospace;
+        border: thin solid black;
+        background-color: #F8F8F8;
+        padding: 1ex;
+      }
+      #testDiv { display: block; }
+    </style>
+  </head>
   <body>
-    <p>
+    <section>
+      Initial setup:
+      <p>
+        To enable the Compose key, open
+        <code>chrome://settings/inputMethods</code>
+        and select one of the <code>Compose Key</code> input methods.
+      </p>
+      <p>
+        Then, open <code>chrome://settings/languages</code>
+        and enable the selected method.
+        (You may need to sign out and back in first.)
+      </p>
+    </section>
+    <section>
       <label for="key">
-        Key:
+        Compose Key:
         <select id="key">
           <option value="AltRight">Right Alt</option>
           <option value="AltLeft">Left Alt</option>
           <option value="ContextMenu">Menu</option>
-          <option value="CapsLock">Caps Lock</option>
           <option value="ShiftRight">Right Shift</option>
           <option value="ShiftLeft">Left Shift</option>
           <option value="ControlRight">Right Control</option>
           <option value="ControlLeft">Left Control</option>
         </select>
       </label>
-    </p>
+      <p>The key to use as the Compose key.</p>
+      <p>Changes will affect only the current device.</p>
+      <p>If the key is an Alt, Shift, or Control key, its existing behavior will be preserved to the extent possible.</p>
+    </section>
+    <section>
+      <textarea id="testArea" rows=5 cols=100>Test here! To write ½, press and release Compose followed by &lt;1&gt; &lt;2&gt;.</textarea>
+      <div id="testDiv" contenteditable=true>Test here too!</div>
+    </section>
 
     <script src="options.js"></script>
   </body>

--- a/composekey/options.html
+++ b/composekey/options.html
@@ -21,6 +21,10 @@
         padding: 1ex;
       }
       #testDiv { display: block; }
+      keyInputs {
+        display: inline-block
+        vertical-align: top
+      }
     </style>
   </head>
   <body>
@@ -38,8 +42,7 @@
       </p>
     </section>
     <section>
-      <label for="key">
-        Compose Key:
+      <label>Compose Key:
         <select id="key">
           <option value="AltRight">Right Alt</option>
           <option value="AltLeft">Left Alt</option>
@@ -50,9 +53,16 @@
           <option value="ControlLeft">Left Control</option>
         </select>
       </label>
+      <label id="keepModifierLabel">
+				<input id="keepModifier" type="checkbox" checked>
+        Keep modifier
+      </label>
       <p>The key to use as the Compose key.</p>
       <p>Changes will affect only the current device.</p>
-      <p>If the key is an Alt, Shift, or Control key, its existing behavior will be preserved to the extent possible.</p>
+      <p>If <q>Keep modifer</q> is checked and the key is an Alt, Shift, or
+        Control key, the key will continue to modify other keystrokes as usual.
+        It will only act as Compose if pressed and released without another
+        intervening keystroke.</p>
     </section>
     <section>
       <textarea id="testArea" rows=5 cols=100>Test here! To write ½, press and release Compose followed by &lt;1&gt; &lt;2&gt;.</textarea>

--- a/composekey/options.html
+++ b/composekey/options.html
@@ -20,11 +20,7 @@
         background-color: #F8F8F8;
         padding: 1ex;
       }
-      #testDiv { display: block; }
-      keyInputs {
-        display: inline-block
-        vertical-align: top
-      }
+      #testDiv { display: none; }
     </style>
   </head>
   <body>

--- a/composekey/options.js
+++ b/composekey/options.js
@@ -1,22 +1,60 @@
-function saveAndSync() {
-  var key = document.getElementById('key').value;
-  chrome.extension.getBackgroundPage().setKey(key);
+/*
+Copyright 2014 Google Inc. All rights reserved.
 
-  chrome.storage.sync.set({ key: key }, function() {
-    console.log("sync'd key as " + key);
-  })
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+let backgroundPage = chrome.extension
+    ? chrome.extension.getBackgroundPage()
+    : this;
+
+if (!chrome.extension) {
+  // We've loaded options.html without actually being in an extension,
+  // presumably in order to test it.
+  // Fake an extension environment by loading background.js explicitly.
+  for (let src of ['fakes.js', 'background.js']) {
+    let script = document.createElement('script');
+    script.src = src;
+    script.onload = restore;
+    document.body.appendChild(script);
+  }
+}
+
+for (let eventType of ['keydown', 'keypress', 'keyup', 'textInput']) {
+  document.getElementById('testArea')
+    .addEventListener(eventType, (event) => {
+      console.log('testArea ', eventType, ": ", event)
+    }, {passive: true})
 }
 
 function restore() {
-  document.getElementById('key').value =
-      chrome.extension.getBackgroundPage().composeKey;
-  document.addEventListener('storage', function(event) {
-    var old = document.getElementById('key').value;
-    if (event.key == 'key' && event.newValue != old) {
-      document.getElementById('key').value = event.newValue;
-    }
-  })
+  let key = document.getElementById('key');
+  if (key.value != backgroundPage.composeKey) {
+    key.value = backgroundPage.composeKey;
+  }
 }
-
 document.addEventListener('DOMContentLoaded', restore);
-document.getElementById('key').addEventListener('input', saveAndSync);
+backgroundPage.onComposeKeyLoaded = restore;
+
+document.getElementById('key')
+  .addEventListener('change', (event) => {
+    if (event.target.value != backgroundPage.composeKey) {
+      backgroundPage.storeKey(event.target.value);
+    }
+  },{passive: true});
+
+function updateComposeFile() {
+  let content = document.getElementById('composeFile').value;
+  if (content != backgroundPage.composeFile)
+    backgroundPage.storeComposeFile(content);
+}

--- a/composekey/options.js
+++ b/composekey/options.js
@@ -41,7 +41,10 @@ function restore() {
   let key = document.getElementById('key');
   if (key.value != backgroundPage.composeKey) {
     key.value = backgroundPage.composeKey;
+    document.getElementById('keepModifierLabel').style.display =
+        (key.value == 'ContextMenu') ? 'none' : 'unset';
   }
+
   let keepModifier = document.getElementById('keepModifier');
   if (keepModifier.checked != backgroundPage.keepModifier) {
     keepModifier.checked = backgroundPage.keepModifier;
@@ -51,18 +54,15 @@ document.addEventListener('DOMContentLoaded', restore);
 backgroundPage.onComposeKeyLoaded = restore;
 
 function keyChanged() {
-  let key = document.getElementById('key').value;
-  let keepModifierLabel = document.getElementById('keepModifierLabel');
-  if (key == 'ContextMenu') {
-    keepModifierLabel.style.display = 'none';
-    keepModifier = false;
-  } else {
-    keepModifierLabel.style.display = 'unset';
-    keepModifier = document.getElementById('keepModifier').checked;
-  }
+  let key = document.getElementById('key');
+  document.getElementById('keepModifierLabel').style.display =
+      (key.value == 'ContextMenu') ? 'none' : 'unset';
+
+  let keepModifier = document.getElementById('keepModifier');
+
   backgroundPage.storeKey({
-    key: key,
-    keepModifier: keepModifier,
+    key: key.value,
+    keepModifier: keepModifier.checked,
   });
 }
 document.getElementById('key')

--- a/composekey/options.js
+++ b/composekey/options.js
@@ -42,19 +42,30 @@ function restore() {
   if (key.value != backgroundPage.composeKey) {
     key.value = backgroundPage.composeKey;
   }
+  let keepModifier = document.getElementById('keepModifier');
+  if (keepModifier.checked != backgroundPage.keepModifier) {
+    keepModifier.checked = backgroundPage.keepModifier;
+  }
 }
 document.addEventListener('DOMContentLoaded', restore);
 backgroundPage.onComposeKeyLoaded = restore;
 
-document.getElementById('key')
-  .addEventListener('change', (event) => {
-    if (event.target.value != backgroundPage.composeKey) {
-      backgroundPage.storeKey(event.target.value);
-    }
-  },{passive: true});
-
-function updateComposeFile() {
-  let content = document.getElementById('composeFile').value;
-  if (content != backgroundPage.composeFile)
-    backgroundPage.storeComposeFile(content);
+function keyChanged() {
+  let key = document.getElementById('key').value;
+  let keepModifierLabel = document.getElementById('keepModifierLabel');
+  if (key == 'ContextMenu') {
+    keepModifierLabel.style.display = 'none';
+    keepModifier = false;
+  } else {
+    keepModifierLabel.style.display = 'unset';
+    keepModifier = document.getElementById('keepModifier').checked;
+  }
+  backgroundPage.storeKey({
+    key: key,
+    keepModifier: keepModifier,
+  });
 }
+document.getElementById('key')
+  .addEventListener('change', keyChanged, {passive: true});
+document.getElementById('keepModifier')
+  .addEventListener('change', keyChanged, {passive: true});


### PR DESCRIPTION
This is mostly a preparatory change for supporting arbitrary XCompose sequences, but it at least partially addresses issue #10.

Full XCompose support is also implemented on a branch in my fork (https://github.com/bcmills/extra-keyboards-for-chrome-os/tree/custom-sequences), if you want to look ahead to see how it comes together.