### PR TITLE
removed duplicate and broken resetState function

### DIFF
--- a/composekey/background.js
+++ b/composekey/background.js
@@ -1612,13 +1612,6 @@ function resetState() {
   composeOnKeyUp = false;
 }
 
-function resetState() {
-  states = rootState;
-  composing = false;
-  keyDownSuppressed = new Set();
-  composeOnKeyUp = false;
-}
-
 /**
  * The set of Javascript key events that correspond to modifier keys.
  * @type {Set<string>}


### PR DESCRIPTION
the correction version of the function is right above it. Without this I was unable to type at all with the compose keyboard selected. 