### PR TITLE
Add link to UK Colemak extension in Chrome web store

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Note that the version on the webstore may not be as up-to-date as on GitHub.
 - [Programmer Dvorak](https://chrome.google.com/webstore/detail/programmer-dvorak/mogcmmflienoigckdgnkkkafbgkaecbj)
 - [Polish Dvorak](https://chrome.google.com/webstore/detail/polish-dvorak/gikieikejljogkfjbijjplfhbmhbmfkf)
 - [Dvorak right](https://chrome.google.com/webstore/detail/dvorak-right/ibmblmkjihglholefminaiddohamopnn)
+- [UK Colemak](https://chrome.google.com/webstore/detail/nionfllpgckhdmcecikpfkonedlmlnop) (published by third party)
 
 ## How to Use
 


### PR DESCRIPTION
Add link to UK Colemak extension built from this repository. NB. This is published by a third party rather than by Google.