### PR TITLE
dvorak-intl: Set manifest_version to 3 and version to 1.1.

### DIFF
--- a/dvorak-intl/manifest.json
+++ b/dvorak-intl/manifest.json
@@ -14,8 +14,8 @@ limitations under the License.
 */
 {
   "name": "Dvorak International",
-  "version": "1.0",
-  "manifest_version": 2,
+  "version": "1.1",
+  "manifest_version": 3,
   "description": "Dvorak International keyboard",
   "permissions": [
     "input"


### PR DESCRIPTION
Chrome dropped support for Manifest V2 extensions, so update the dvorak-intl layout to specify V3. As far as I can tell, no additional changes are needed. See #120.