### PR TITLE
Update options.js DOM text reinterpreted as HTML

### DIFF
--- a/composekey/options.js
+++ b/composekey/options.js
@@ -163,7 +163,7 @@ function updateComposeFileStatus() {
   const errors = document.getElementById('errors');
   const warnings = document.getElementById('warnings');
   for (let elem of [errors, warnings]) {
-    elem.innerHTML = '';
+    elem.innerText = '';
     elem.style.display = 'none';
   }
 


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.

