### PR TITLE
Add Indic-language INSCRIPT keyboards.

### DIFF
--- a/indic/README.md
+++ b/indic/README.md
@@ -1,4 +1,3 @@
-This adds several Indic-language keyboards to Chrome OS. In particular, these
-keyboards support Inscript layouts (https://en.wikipedia.org/wiki/InScript_keyboard).
+This adds several Indic-language input methods to Chrome OS. In particular, adds support for several Inscript layouts (https://en.wikipedia.org/wiki/InScript_keyboard).
 
-All of the keyboards in this extension are based on [XKB](../example/xkb/README.md).
+All of the input methods in this extension are based on [XKB](../example/xkb/README.md).

--- a/indic/README.md
+++ b/indic/README.md
@@ -1,0 +1,4 @@
+This adds several Indic-language keyboards to Chrome OS. In particular, these
+keyboards support Inscript layouts (https://en.wikipedia.org/wiki/InScript_keyboard).
+
+All of the keyboards in this extension are based on [XKB](../example/xkb/README.md).

--- a/indic/manifest.json
+++ b/indic/manifest.json
@@ -1,0 +1,67 @@
+{
+    "name": "Inscript keyboards",
+    "version": "1.0",
+    "manifest_version": 3,
+    "description": "Indic language keyboards in Inscript",
+    "permissions": [
+	"input"
+    ],
+    "input_components": [
+	{
+	    "name": "Hindi (Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_hi",
+	    "description": "Hindi Devanagari (Inscript) layout",
+	    "language": ["hi"],
+	    "layouts": ["in(deva)"]
+	},
+	{
+	    "name": "Marathi (Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_mr",
+	    "description": "Marathi (Inscript) layout",
+	    "language": ["mr"],
+	    "layouts": ["in(deva)"]
+	},
+	{
+	    "name": "Kannada (Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_kan",
+	    "description": "Kannada (Inscript) layout",
+	    "language": ["kn"],
+	    "layouts": ["in(kan)"]
+	},
+	{
+	    "name": "Odia (Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_ori",
+	    "description": "Odia (Inscript) layout",
+	    "language": ["or"],
+	    "layouts": ["in(ori)"]
+	},
+	{
+	    "name": "Telugu (Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_tel",
+	    "description": "Telugu (Inscript) layout",
+	    "language": ["te"],
+	    "layouts": ["in(tel)"]
+	},
+	{
+	    "name": "Malayalam (Enhanced Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_mal",
+	    "description": "Malayalam (Inscript) layout",
+	    "language": ["ml"],
+	    "layouts": ["in(mal)"]
+	},
+	{
+	    "name": "Bangla (India, Baisakhi Inscript)",
+	    "type": "ime",
+	    "id": "ajitnarayanan_inscript_xkb_in_ben",
+	    "description": "Bangla (Inscript) layout",
+	    "language": ["bn"],
+	    "layouts": ["in(ben)"]
+	}
+    ]
+}


### PR DESCRIPTION
Languages added: Hindi, Marathi, Kannada, Telugu, Odia, and Bengali. All these layouts are supported by XKB 2.27, so the manifest simply refers to the corresponding xkb layouts.