### PR TITLE
Update composekey to manifest v3

### DIFF
--- a/composekey/manifest.json
+++ b/composekey/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "ComposeKey",
   "version": "1.8",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "Compose Key for Chrome OS",
   "background": {
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "icons": {
     "48": "icon48.png",
@@ -113,7 +113,6 @@
     }
   ],
   "options_ui": {
-    "page": "options.html",
-    "chrome_style": true
+    "page": "options.html"
   }
 }


### PR DESCRIPTION
Derived from original work by @gutschke on github (see #147).

Use new storage API.  Fix up situation where the callbacks can be invoked in an environment where KeyboardEvent isn't defined (and it can't detect the "location" correctly).